### PR TITLE
update escape-string-regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
-'use strict';
-const escapeStringRegexp = require('escape-string-regexp');
-const mapping = require('./lib/mappings');
+import escapeStringRegexp from 'escape-string-regexp';
+import mapping from './lib/mappings.js';
 
 const hasFlags = (regexFlags, replaceFlags) => {
 	if (!replaceFlags) {
@@ -11,9 +10,7 @@ const hasFlags = (regexFlags, replaceFlags) => {
 	return replaceFlags.split('').every(flag => regexFlags.includes(flag));
 };
 
-module.exports = (regexp, flags) => {
-	flags = flags || '';
-
+export default function cleanRegexp(regexp, flags = '') {
 	if (typeof regexp !== 'string') {
 		throw new TypeError(`Expected regexp to be of type \`string\`, got \`${typeof regexp}\``);
 	}
@@ -22,14 +19,11 @@ module.exports = (regexp, flags) => {
 		throw new TypeError(`Expected flags to be of type \`string\`, got \`${typeof flags}\``);
 	}
 
-	for (const replace of mapping) {
-		const key = replace[0];
-		const replacement = replace[1];
-
+	for (const [key, replacement] of mapping) {
 		if (hasFlags(flags, replacement.flags)) {
 			regexp = regexp.replace(new RegExp(escapeStringRegexp(key), 'g'), replacement.value);
 		}
 	}
 
 	return regexp;
-};
+}

--- a/lib/mappings.js
+++ b/lib/mappings.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = new Map([
+export default new Map([
 	['[0-9]', {value: '\\d'}],
 	['[^0-9]', {value: '\\D'}],
 
@@ -139,5 +137,5 @@ module.exports = new Map([
 	['[^\\da-z_]', {value: '\\W', flags: 'i'}],
 	['[^\\d_a-z]', {value: '\\W', flags: 'i'}],
 	['[^_a-z\\d]', {value: '\\W', flags: 'i'}],
-	['[^_\\da-z]', {value: '\\W', flags: 'i'}]
+	['[^_\\da-z]', {value: '\\W', flags: 'i'}],
 ]);

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "email": "sam.verschueren@gmail.com",
     "url": "github.com/SamVerschueren"
   },
+  "type": "module",
   "engines": {
-    "node": ">=4"
+    "node": "12.20"
   },
   "scripts": {
     "test": "xo && ava"
@@ -30,7 +31,7 @@
     "word"
   ],
   "dependencies": {
-    "escape-string-regexp": "^1.0.5"
+    "escape-string-regexp": "^5.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from '.';
+import m from './index.js';
 
 function macro(t, regex, flags, expected) {
 	if (!expected) {
@@ -43,6 +43,12 @@ test(macro, '[0-9]+\\.[^0-9]?\\.[a-zA-Z0-9_]+\\.[^a-z0-9_]', 'i', '\\d+\\.\\D?\\
 test(macro, '[0-9]+\\.[^0-9]?\\.[a-zA-Z0-9_]+\\.[^a-z0-9_]', 'g', '\\d+\\.\\D?\\.\\w+\\.[^a-z0-9_]');
 
 test('error', t => {
-	t.throws(() => m(98), 'Expected regexp to be of type `string`, got `number`');
-	t.throws(() => m('[0-9]', {}), 'Expected flags to be of type `string`, got `object`');
+	t.throws(() => m(98), {
+		message: 'Expected regexp to be of type `string`, got `number`',
+		name: 'TypeError',
+	});
+	t.throws(() => m('[0-9]', {}), {
+		message: 'Expected flags to be of type `string`, got `object`',
+		name: 'TypeError',
+	});
 });


### PR DESCRIPTION
`escape-string-regexp` became a ESM only package, to update to v5 we also need to switch to ESM only.

few new rules got added, fixed those as well.